### PR TITLE
Fix SQL query to use wildcard for book name search

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE %s", name
+            "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix book lookup so that name searches match substrings rather than only exact or prefix matches.